### PR TITLE
implementation of productN

### DIFF
--- a/src/OSeq.ml
+++ b/src/OSeq.ml
@@ -529,6 +529,7 @@ let product l1 l2 =
 
 let app fs xs = product_with (fun f x -> f x) fs xs
 
+
 module Infix = struct
   let (>>=) xs f = flat_map f xs
   let (>|=) xs f = map f xs
@@ -541,6 +542,26 @@ module Infix = struct
 end
 
 include Infix
+
+let product3 l1 l2 l3 =
+  (fun x1 x2 x3 -> x1,x2,x3)
+  |> return <*> l1 <*> l2 <*> l3
+
+let product4 l1 l2 l3 l4 =
+  (fun x1 x2 x3 x4 -> x1,x2,x3,x4)
+  |> return <*> l1 <*> l2 <*> l3 <*> l4
+
+let product5 l1 l2 l3 l4 l5 =
+  (fun x1 x2 x3 x4 x5 -> x1,x2,x3,x4,x5)
+  |> return <*> l1 <*> l2 <*> l3 <*> l4 <*> l5
+
+let product6 l1 l2 l3 l4 l5 l6 =
+  (fun x1 x2 x3 x4 x5 x6 -> x1,x2,x3,x4,x5,x6)
+  |> return <*> l1 <*> l2 <*> l3 <*> l4 <*> l5 <*> l6
+
+let product7 l1 l2 l3 l4 l5 l6 l7 =
+  (fun x1 x2 x3 x4 x5 x6 x7 -> x1,x2,x3,x4,x5,x6,x7)
+  |> return <*> l1 <*> l2 <*> l3 <*> l4 <*> l5 <*> l6 <*> l7
 
 let rec group ~eq l () = match l() with
   | Nil -> Nil

--- a/src/OSeq.mli
+++ b/src/OSeq.mli
@@ -262,6 +262,23 @@ val product : 'a t -> 'b t -> ('a * 'b) t
 (** Cartesian product, in no predictable order. Works even if some of the
     arguments are infinite. *)
 
+val product3 : 'a t -> 'b t -> 'c t -> ('a * 'b * 'c) t
+(** Cartesian product of three iterators, see product. *)
+
+val product4 : 'a t -> 'b t -> 'c t -> 'd t -> ('a * 'b * 'c * 'd) t
+(** Cartesian product of four iterators, see product. *)
+
+val product5 : 'a t -> 'b t -> 'c t -> 'd t -> 'e t -> ('a * 'b * 'c * 'd * 'e) t
+(** Cartesian product of five iterators, see product. *)
+
+val product6 : 'a t -> 'b t -> 'c t -> 'd t -> 'e t -> 'f t
+   ->  ('a * 'b * 'c * 'd * 'e * 'f) t
+(** Cartesian product of six iterators, see product. *)
+
+val product7 : 'a t -> 'b t -> 'c t -> 'd t -> 'e t -> 'f t -> 'g t
+   ->  ('a * 'b * 'c * 'd * 'e * 'f * 'g) t
+(** Cartesian product of seven iterators, see product. *)
+
 val group : eq:('a -> 'a -> bool) -> 'a t -> 'a t t
 (** Group equal consecutive elements together. *)
 


### PR DESCRIPTION
cartesian product over producing tuples up to N=7. naively implemented
using the app combinator.

no idea about performance implications? if we want to iterate a side-effecting function over nested variables, will constructing the tuples cost a lot of time?

initially i had it without infix notation, but that required defining an argument-swapped version of app. the present way is more concise.